### PR TITLE
ignore BOM characters if G&L csv file is encoded as utf8 with BOM

### DIFF
--- a/tax.py
+++ b/tax.py
@@ -49,7 +49,7 @@ def calc_tax(input_file_path, output_file, csv_file):
     fractional_lots = []
 
     # read in gain&loss csv file
-    with open(input_file_path, 'r') as file:
+    with open(input_file_path, 'r', encoding='utf-8-sig') as file:
         csv_reader = csv.DictReader(file)
         gain_loss_data = [row for row in csv_reader]
 


### PR DESCRIPTION
On Windows, downloading the G&L xlsx file, opening in Excel and then saving to csv results in the first (header) row being preceded by BOM characters.  For example:

`ï»¿Record Type,Symbol,Plan Type,Qty.,Date Acquired,...`

Running tax.py throws the following error when trying to reference the "Record Type" column in the first row because the first header column is actually "ï»¿Record Type" when the BOM characters exist.

```
Traceback (most recent call last):
  File "C:\Users\tax-tool-main\tax.py", line 217, in <module>
    main()
  File "C:\Users\tax-tool-main\tax.py", line 38, in main
    calc_tax(args.input, output_file, csv_file)
  File "C:\Users\tax-tool-main\tax.py", line 62, in calc_tax
    if row["Symbol"] == "VMW" and row["Record Type"] == "Sell":
                                  ~~~^^^^^^^^^^^^^^^
KeyError: 'Record Type'
```


Opening the G&L input csv file with encoding "utf-8-sig" safely ignores the BOM characters.